### PR TITLE
Add msecs-to-timestamp as a common function

### DIFF
--- a/subed/subed.el
+++ b/subed/subed.el
@@ -110,6 +110,7 @@
   (list "subtitle-id" "subtitle-id-max" "subtitle-id-at-msecs"
         "subtitle-msecs-start" "subtitle-msecs-stop"
         "subtitle-text" "subtitle-relative-point"
+        "msecs-to-timestamp"
         "jump-to-subtitle-id" "jump-to-subtitle-id-at-msecs"
         "jump-to-subtitle-time-start" "jump-to-subtitle-time-stop"
         "jump-to-subtitle-text" "jump-to-subtitle-text-at-msecs"

--- a/tests/test-subed-srt.el
+++ b/tests/test-subed-srt.el
@@ -1473,3 +1473,7 @@ Baz.
         (expect (point) :to-equal 33)))
     )
   )
+(describe "Converting msecs to timestamp"
+  (it "uses the right format"
+    (with-temp-srt-buffer
+     (expect (subed-msecs-to-timestamp 1401) :to-equal "00:00:01,401"))))

--- a/tests/test-subed-vtt.el
+++ b/tests/test-subed-vtt.el
@@ -1133,4 +1133,8 @@ Baz.
          (subed-vtt--sort)
          (expect (point) :to-equal (1- (point-max)))))
       )
-    ))
+    )
+  (describe "Converting msecs to timestamp"
+    (it "uses the right format"
+      (with-temp-vtt-buffer
+       (expect (subed-msecs-to-timestamp 1401) :to-equal "00:00:01.401")))))


### PR DESCRIPTION
That way, calling it from a WebVTT file uses the right format.

* subed/subed.el (subed--generic-function-suffixes): Add
  msecs-to-timestamp.
* tests/test-subed-srt.el ("Converting msecs to timestamp"):
  Add test.
* tests/test-subed-vtt.el ("VTT"): Add test.