### PR TITLE
Trim overlaps

### DIFF
--- a/subed/subed-common.el
+++ b/subed/subed-common.el
@@ -1296,13 +1296,14 @@ be run in `after-change-functions'."
 
 ;;; handle overlapping subtitle timecodes
 
-;; NB: runs in a hook, so this version cannot send prefix arg
-;; to subed-sanitize-overlaps!
+;; NB: runs in a hook, so this version cannot send prefix arg to
+;; subed-sanitize-overlaps
 (defun subed-check-overlaps ()
   "Test all subtitles for overlapping timecodes.
 
-Creates a list of the ids of overlapping subtitles, moves point to the to the end time of the first one, and prompts to trim them.
-Designed to be run as a subed-mode-hook."
+Creates a list of the ids of overlapping subtitles, moves point
+to the to the end time of the first one, and prompts to trim
+them. Designed to be run as a subed-mode-hook."
   (interactive)
   (let ((overlap-ids ()))
     (save-excursion
@@ -1326,10 +1327,15 @@ Designed to be run as a subed-mode-hook."
 (defun subed-sanitize-overlaps (&optional arg)
   "Adjust all overlapping times in current file.
 
-Uses either `subed-trim-overlap-start-times' or `subed-trim-overlapping-end-times', the latter being the default. See `subed-trim-overlapping-subtitle-trim-start' to customize this option.
+Uses either `subed-trim-overlap-start-times' or
+`subed-trim-overlapping-end-times', the latter being the default.
+See `subed-trim-overlapping-subtitle-trim-start' to customize
+this option.
 
-With a non-numerical prefix ARG, or if `subed-trim-overlapping-use-subed-subtitle-spacing' is t, make a gap the between subtitles the length of `subed-subtitle-spacing'.
-With a numerical prefix ARG, make the gap that many milliseconds."
+With a non-numerical prefix ARG, or if
+`subed-trim-overlapping-use-subed-subtitle-spacing' is t, make a gap the
+between subtitles the length of `subed-subtitle-spacing'. With a numerical
+prefix ARG, make the gap that many milliseconds."
   (interactive "P")
   (let ((cpsp (subed-show-cps-p)))
     (when cpsp
@@ -1348,10 +1354,14 @@ With a numerical prefix ARG, make the gap that many milliseconds."
 (defun subed-trim-overlap-end-time (&optional arg)
   "Check if end time of current subtitle is after start time of next.
 
-If so, trim the end time of current subtitle to 1 millisecond less than the start time of the next one.
+If so, trim the end time of current subtitle to 1 millisecond
+less than the start time of the next one.
 
-With a non-numerical prefix ARG, or if `subed-trim-overlapping-use-subed-subtitle-spacing' is t, make a gap the between subtitles the length of `subed-subtitle-spacing'.
-With a numerical prefix ARG, make the gap that many milliseconds."
+With a non-numerical prefix ARG, or if
+`subed-trim-overlapping-use-subed-subtitle-spacing' is t, make a
+gap the between subtitles the length of `subed-subtitle-spacing'.
+With a numerical prefix ARG, make the gap that many
+milliseconds."
   (interactive "P")
   (let ((next-sub-start-time (save-excursion
                                (subed-forward-subtitle-time-start)
@@ -1373,9 +1383,12 @@ With a numerical prefix ARG, make the gap that many milliseconds."
 (defun subed-trim-overlap-start-time (&optional arg)
   "Check if end time of current subtitle is after start time of next.
 
-If so, trim the start time of current subtitle to 1 millisecond less than the end time of the current one.
+If so, trim the start time of current subtitle to 1 millisecond
+less than the end time of the current one.
 
-With a non-numerical prefix ARG, or if `subed-trim-overlapping-use-subed-subtitle-spacing' is t, make a gap the between subtitles the length of `subed-subtitle-spacing'.
+With a non-numerical prefix ARG, or if
+`subed-trim-overlapping-use-subed-subtitle-spacing' is t, make a
+gap the between subtitles the length of `subed-subtitle-spacing'.
 With a numerical prefix ARG make the gap that many miliseconds."
   (interactive "P")
   (let ((this-sub-stop-time (subed-subtitle-msecs-stop))
@@ -1398,7 +1411,6 @@ With a numerical prefix ARG make the gap that many miliseconds."
             (t
              (1+ this-sub-stop-time))))))))
 
-;; mod subed-sort fun to run santize-overlaps if enabled:
 (defun subed-sort ()
   "Sanitize, then sort subtitles by start time and re-number them."
   (interactive)

--- a/subed/subed-config.el
+++ b/subed/subed-config.el
@@ -210,6 +210,27 @@ hardcoded."
   "Return base name of buffer file name or a default name."
   (file-name-nondirectory (or (buffer-file-name) "unnamed")))
 
+;; checked by subed-sort
+(defcustom subed-trim-overlapping-subtitle-times-on-save nil
+  "Whether all overlapping subtitles should be trimmed on saving. Subtitles are trimmed according to `subed-trim-overlapping-subtitle-start-or-end'."
+  :type 'boolean
+  :group 'subed)
+
+;; checked by subed mode hook
+(defcustom subed-check-overlapping-subtitle-times-on-load nil
+  "Whether to check for, and optionally trim, overlapping subtitles on entering subed mode. Subtitles are trimmed according to `subed-trim-overlapping-subtitle-start-or-end'."
+  :type 'boolean
+  :group 'subed)
+
+(defcustom subed-trim-overlapping-subtitle-trim-start nil
+  "How overlapping subtitles should be trimmed. If t, adjust the start time of the following subtitle, if nil, adjust the end of the current subtitle. Defaults to nil."
+  :type 'boolean
+  :group 'subed)
+
+(defcustom subed-trim-overlapping-use-subed-subtitle-spacing nil
+  "Whether `subed-subtitle-spacing' should be used when trimming overlapping subtitles. If nil, subtitles will trimmed to one millisecond less than adjacent one. Defaults to nil. You can also set the spacing by using a prefix arg when calling `subed-sanitize-overlaps', which see."
+  :type 'boolean
+  :group 'subed)
 
 ;; Hooks
 

--- a/subed/subed-config.el
+++ b/subed/subed-config.el
@@ -212,23 +212,34 @@ hardcoded."
 
 ;; checked by subed-sort
 (defcustom subed-trim-overlapping-subtitle-times-on-save nil
-  "Whether all overlapping subtitles should be trimmed on saving. Subtitles are trimmed according to `subed-trim-overlapping-subtitle-start-or-end'."
+  "Whether all overlapping subtitles should be trimmed on saving.
+Subtitles are trimmed according to
+`subed-trim-overlapping-subtitle-start-or-end'."
   :type 'boolean
   :group 'subed)
 
 ;; checked by subed mode hook
 (defcustom subed-check-overlapping-subtitle-times-on-load nil
-  "Whether to check for, and optionally trim, overlapping subtitles on entering subed mode. Subtitles are trimmed according to `subed-trim-overlapping-subtitle-start-or-end'."
+  "Whether to check for, and optionally trim, overlapping
+subtitles on entering subed mode. Subtitles are trimmed according
+to `subed-trim-overlapping-subtitle-start'. Defaults to nil."
   :type 'boolean
   :group 'subed)
 
 (defcustom subed-trim-overlapping-subtitle-trim-start nil
-  "How overlapping subtitles should be trimmed. If t, adjust the start time of the following subtitle, if nil, adjust the end of the current subtitle. Defaults to nil."
+  "How overlapping subtitles should be trimmed. If t, adjust the
+start time of the following subtitle, if nil, adjust the end of
+the current subtitle. Defaults to nil."
   :type 'boolean
   :group 'subed)
 
 (defcustom subed-trim-overlapping-use-subed-subtitle-spacing nil
-  "Whether `subed-subtitle-spacing' should be used when trimming overlapping subtitles. If nil, subtitles will trimmed to one millisecond less than adjacent one. Defaults to nil. You can also set the spacing by using a prefix arg when calling `subed-sanitize-overlaps', which see."
+  "Whether `subed-subtitle-spacing' should be used when trimming
+overlapping subtitles. If nil, subtitles will trimmed to one
+millisecond less than adjacent one. Defaults to nil.
+
+Spacing can also be set by using a prefix arg when calling
+`subed-sanitize-overlaps', which see."
   :type 'boolean
   :group 'subed)
 

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -197,6 +197,8 @@ Key bindings:
   (add-hook 'after-save-hook #'subed-mpv-reload-subtitles :append :local)
   (add-hook 'kill-buffer-hook #'subed-mpv-kill :append :local)
   (add-hook 'kill-emacs-hook #'subed-mpv-kill :append :local)
+  (when subed-check-overlapping-subtitle-times-on-load
+    (add-hook 'subed-mode-hook #'subed-check-overlaps :append :local))
   (when subed-auto-find-video
     (let ((video-file (subed-guess-video-file)))
       (when video-file


### PR DESCRIPTION
i had a crack at implementing trimming overlapping subtitles and thought i would share what i came up with.

as per rndusr's recommendations, it includes

- customize option to ask to trim on load
- customize option to always trim on save
- custom options and prefix args to trim by:
   - any number of milliseconds
   - the value of subed-subtitle-spacing, or
   - 1 millisecond
- customize option to either trim end of current or start of next sub.

personally i only have experience with .srt subtitle files, so that is all i have used this with. i also don't know the codebase super well. but thought i would share my efforts nonetheless.
