### PR TITLE
Fix "I"/"O" insertion on focus events when Emacs runs in terminal

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,9 +34,10 @@ formats are:
   many subtitles to insert and whether they are inserted before or after the
   current subtitle.
 - Kill subtitles (~M-k~).
-- Adjust subtitle start (~M-[~ / ~M-]~) and stop (~M-{~ / ~M-}~) time.  A
-  prefix argument sets the number of milliseconds for the current session
-  (e.g. ~C-u 1000 M-[ M-[ M-[~ decreases start time by 3 seconds).
+- Adjust subtitle start (~M-[~ / ~M-]~ or ~C-M-[~ / ~C-M-]~ if Emacs lives in a
+  terminal) and stop (~M-{~ / ~M-}~) time.  A prefix argument sets the number of
+  milliseconds for the current session (e.g. ~C-u 1000 M-[ M-[ M-[~ decreases
+  start time by 3 seconds).
 - Move the current subtitle or all marked subtitles
   (~subed-move-subtitles~) forward (~C-M-n~) or backward (~C-M-p~) in
   time without changing subtitle duration.  A prefix argument sets the

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -52,8 +52,18 @@
     (define-key subed-mode-map (kbd "M-p") #'subed-backward-subtitle-text)
     (define-key subed-mode-map (kbd "C-M-a") #'subed-jump-to-subtitle-text)
     (define-key subed-mode-map (kbd "C-M-e") #'subed-jump-to-subtitle-end)
-    (define-key subed-mode-map (kbd "M-[") #'subed-decrease-start-time)
-    (define-key subed-mode-map (kbd "M-]") #'subed-increase-start-time)
+    ;; Binding M-[ when Emacs runs in a terminal emulator inserts "O" and "I"
+    ;; every time the terminal window looses/gains focus.
+    ;; https://emacs.stackexchange.com/questions/48738
+    ;; https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-FocusIn_FocusOut
+    ;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Input-Focus.html
+    (if (display-graphic-p)
+        (progn
+          (define-key subed-mode-map (kbd "M-[") #'subed-decrease-start-time)
+          (define-key subed-mode-map (kbd "M-]") #'subed-increase-start-time))
+      (progn
+        (define-key subed-mode-map (kbd "C-M-[") #'subed-decrease-start-time)
+        (define-key subed-mode-map (kbd "C-M-]") #'subed-increase-start-time)))
     (define-key subed-mode-map (kbd "M-{") #'subed-decrease-stop-time)
     (define-key subed-mode-map (kbd "M-}") #'subed-increase-stop-time)
     (define-key subed-mode-map (kbd "C-M-n") #'subed-move-subtitle-forward)


### PR DESCRIPTION
If Emacs runs in a terminal emulator, the characters "I"/"O" are inserted in the
buffer every time the terminal window is focused/unfocused.

Emacs tells the terminal emulator to send focus in/out events, and they are sent
as "\e[I" (focus in) and "\e[O" (focus out). "\e" is the escape character.

Alt/Meta combinations are sent as "\eC" where "C" is the key pressed together
with Alt. For example, if you press `M-x`, the terminal emulator sends an escape
character and "x".

And if you press `M-[`, "\e[" is sent which is indistinguishable from the
beginning of the "\e[I" or "\e[O" event. For some reason I don't know, Emacs
doesn't bother peeking at the next character. It sees "\e[", sees that this
character sequence is bound and acts on it. Then it sees "I" or "O", which are
just letters, so they are inserted as if you pressed those keys.

Further reading:
https://emacs.stackexchange.com/questions/1020/problems-with-keybindings-when-using-terminal/13957#13957

This should be fixable in Emacs itself, but I have no idea exactly how, and the
fact that such an annoying bug hasn't been fixed yet tells me it's actually not
that easy.

This PR simply doesn't map `M-[` if Emacs is running in a terminal emulator and
uses `C-M-[` instead.
