### PR TITLE
Add support for "mov" file extension (fix #67)

### DIFF
--- a/subed/subed-config.el
+++ b/subed/subed-config.el
@@ -85,7 +85,7 @@
   :type 'hook
   :group 'subed)
 
-(defcustom subed-video-extensions '("mkv" "mp4" "webm" "avi" "ts" "ogv")
+(defcustom subed-video-extensions '("mkv" "mp4" "webm" "avi" "ts" "ogv" "mov")
   "Video file name extensions."
   :type 'list
   :group 'subed)


### PR DESCRIPTION
While users can configure this, .mov is a common video file extension that
should be supported out of the box.
