### PR TITLE
subed-waveform: add defcustoms for setting height/width of waveforms

### DIFF
--- a/subed/subed-waveform.el
+++ b/subed/subed-waveform.el
@@ -177,6 +177,18 @@ rounded to the nearest multiple of this number."
   :type 'integer
   :group 'subed-waveform)
 
+(defcustom subed-waveform-image-width nil
+  "Width for images that display the waveforms of one subtitle.
+
+If nil, the width for waveforms is computed in
+`subed-waveform--image-parameters'.")
+
+(defcustom subed-waveform-image-height nil
+  "Height for images that display the waveforms of one subtitle.
+
+If it is nil, the height for waveforms is computed in
+`subed-waveform--image-parameters'.")
+
 (defvar subed-waveform--overlay nil "Overlay if only a single waveform is displayed.")
 (defvar subed-waveform--svg nil "SVG if only a single waveform is displayed.")
 
@@ -618,7 +630,9 @@ This function ignores arguments and can be used in hooks."
       (when (subed-jump-to-subtitle-text)
         (let ((overlay (subed-waveform--get-current-overlay)))
           (when overlay (delete-overlay overlay))
-          (setq overlay (subed-waveform--make-overlay)))))))
+          (setq overlay (subed-waveform--make-overlay
+                         subed-waveform-image-width
+                         subed-waveform-image-height)))))))
 
 (defun subed-waveform-add-to-all ()
   "Update all subtitles with overlays."
@@ -626,7 +640,9 @@ This function ignores arguments and can be used in hooks."
   (remove-overlays (point-min) (point-max) 'subed-waveform t)
   (subed-for-each-subtitle (point-min) (point-max) nil
     (subed-jump-to-subtitle-text)
-    (subed-waveform--make-overlay)))
+    (subed-waveform--make-overlay
+     subed-waveform-image-width
+     subed-waveform-image-height)))
 
 (defun subed-waveform-refresh ()
   "Add all waveforms or just the current one.


### PR DESCRIPTION
Increasing the dimensions of the waveforms helps me to quickly analyze the content of the waveform of the subtitle being edited, so this pull request introduces two variables which allow setting the height and width for the image that display the waveforms.

The two pairs of screenshots and code blocks below show how different configurations can set the size for the image that display the waveforms.

```elisp
(setq subed-waveform-image-width 545)
(setq subed-waveform-image-height 34)
```

![image](https://github.com/user-attachments/assets/762c7daf-c1e4-4f72-9f3b-90beaf4a5bd7)

```elisp
(setq subed-waveform-image-width 800)
(setq subed-waveform-image-height 100)
```

![image](https://github.com/user-attachments/assets/9a4b0716-f2af-46ef-a147-bee8f7145cb9)

If you are a GNU/Linux user, you can use the command below to download a sample video with a sample subtitle from Wikimedia Commons.

```sh
rm -rf /tmp/subtitles \
  && mkdir /tmp/subtitles \
  && curl \
       --output /tmp/subtitles/video.ogv \
       'https://upload.wikimedia.org/wikipedia/commons/4/41/Creative_Commons_and_Commerce.ogv' \
  && curl \
       --data-urlencode 'format=json' \
       --data-urlencode 'action=query' \
       --data-urlencode 'prop=revisions' \
       --data-urlencode 'rvprop=content' \
       --data-urlencode 'rvslots=*' \
       --data-urlencode 'formatversion=2' \
       --data-urlencode 'titles=TimedText:Creative_Commons_and_Commerce.ogv.en.srt' \
       'https://commons.wikimedia.org/w/api.php' | jq --raw-output '.query.pages.[].revisions.[].slots.main.content' > /tmp/subtitles/video.en.srt
```

You can preview my changes by cloning the repository (first code block below), save the second code block below to `/tmp/subtitles/init.el` and use the commands in the third and fourth code block to launch Emacs.

```sh
git clone --depth 1 'https://github.com/rodrigomorales1/subed' /tmp/rodrigomorales1-subed
```

```elisp
(add-to-list 'load-path "/tmp/rodrigomorales1-subed/subed")
(require 'subed-srt)
(require 'subed-waveform)
(add-hook 'subed-mode-hook 'subed-waveform-minor-mode)
(add-hook 'subed-mode-hook 'subed-enable-sync-player-to-point)
(add-hook 'subed-mode-hook 'subed-enable-loop-over-current-subtitle)
(add-hook 'subed-mode-hook 'subed-enable-replay-adjusted-subtitle)
```

```sh
emacs \
  --quick \
  --load /tmp/subtitles/init.el \
  --eval "(setq subed-waveform-image-width 545)" \
  --eval "(setq subed-waveform-image-height 34)" \
  --eval "(find-file \"/tmp/subtitles/video.en.srt\")"
```

```sh
emacs \
  --quick \
  --load /tmp/subtitles/init.el \
  --eval "(setq subed-waveform-image-width 800)" \
  --eval "(setq subed-waveform-image-height 100)" \
  --eval "(find-file \"/tmp/subtitles/video.en.srt\")"
```
